### PR TITLE
move jscs into dev-dependancies so it won't trigger snyk warnings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "main": "dist/Classy.js",
   "license": "MIT",
   "dependencies": {
-    "jscs": "^2.11.0",
     "lodash": "^4.0.0",
     "qs": "^6.1.0",
     "request": "^2.69.0",
@@ -56,6 +55,7 @@
     "gulp-jshint": "^2.0.0",
     "gulp-mocha": "^2.2.0",
     "isparta": "^4.0.0",
+    "jscs": "^2.11.0",
     "jshint": "^2.9.1",
     "lolex": "^1.4.0",
     "mocha": "^2.4.5",

--- a/package.json
+++ b/package.json
@@ -33,10 +33,8 @@
   "license": "MIT",
   "dependencies": {
     "lodash": "^4.0.0",
-    "qs": "^6.1.0",
     "request": "^2.69.0",
-    "request-debug": "^0.2.0",
-    "require-dir": "^0.3.0"
+    "request-debug": "^0.2.0"
   },
   "devDependencies": {
     "babel": "^6.5.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "lodash": "^4.0.0",
     "request": "^2.69.0",
     "request-debug": "^0.2.0",
-    "require-dir": "^0.3.0",
     "snyk": "^1.16.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The only vuln found in classy-node (https://snyk.io/test/npm/classy-node) is via the jscs path, I beleive this should be a devDependancy which snyk would ignore by default. 