### PR TITLE
registrations for campaigns

### DIFF
--- a/src/resources.json
+++ b/src/resources.json
@@ -48,6 +48,7 @@
             "posts",
             "questions",
             "recurring-donation-plans",
+            "registrations",
             "ticket-types",
             "transactions"
         ],


### PR DESCRIPTION
allows use of classy node to search campaign registrations, rather than the appv2 middleware
