### PR TITLE
/message/{id}/stats has been deprecated

### DIFF
--- a/src/resources.json
+++ b/src/resources.json
@@ -248,7 +248,7 @@
     "Messages": {
         "path": "/messages",
         "basic": [ "retrieve", "update", "del" ],
-        "lists": [ "recipients", "supporters", "stats" ],
+        "lists": [ "recipients", "supporters" ],
         "creates": [ "blocks", "attachments", "recipients" ],
         "custom": {
             "methods": {

--- a/src/resources.json
+++ b/src/resources.json
@@ -248,14 +248,10 @@
     "Messages": {
         "path": "/messages",
         "basic": [ "retrieve", "update", "del" ],
-        "lists": [ "recipients", "supporters" ],
+        "lists": [ "recipients", "supporters", "stats" ],
         "creates": [ "blocks", "attachments", "recipients" ],
         "custom": {
             "methods": {
-                "getStats": {
-                    "method": "GET",
-                    "path": "/{id}/stats"
-                },
                 "sendMessage": {
                     "method": "POST",
                     "path": "/{id}/send"


### PR DESCRIPTION
Even though GET /message/{id}/stats is in the API docs, it no longer works and has been deprecated.