### PR TITLE
Typo in Campaign Creates Appeal-Sets

### DIFF
--- a/src/resources.json
+++ b/src/resources.json
@@ -54,7 +54,7 @@
             "transactions"
         ],
         "creates": [
-            "appeal-set",
+            "appeal-sets",
             "credential-sets",
             "donation-matching-plans",
             "ecards",


### PR DESCRIPTION
fixes an issue where you would have had to call `campaigns.createAppealSe()` instead of `campaigns.createAppealSet()`to do a POST to appeal-sets