### PR TITLE
Removed endpoints for retrieving and deleting individual recipients

### DIFF
--- a/src/resources.json
+++ b/src/resources.json
@@ -409,10 +409,6 @@
         "basic": [ "update", "del" ],
         "path": "/questions"
     },
-    "Recipients": {
-        "basic": [ "retrieve", "del" ],
-        "path": "/recipients"
-    },
     "RecurringDonationPlans": {
         "basic": [ "retrieve", "update" ],
         "path": "/recurring-donation-plans"


### PR DESCRIPTION
The endpoints for retrieving and deleting an individual recipient should be private.  
Please note that the endpoints for updating and deleting a list of recipients from a Message are still public.