### PR TITLE
Remove merge tags endpoints

### DIFF
--- a/src/resources.json
+++ b/src/resources.json
@@ -224,18 +224,6 @@
         "lists": [ "organizations", "fundraising-teams", "fundraising-pages" ],
         "path": "/members"
     },
-    "MergeTags": {
-        "path": "/merge-tags",
-        "basic": [ "create", "retrieve", "update" ],
-         "custom": {
-            "methods": {
-                "list": {
-                    "method": "GET",
-                    "path": ""
-                }
-            }
-        }
-    },
     "MessageAttachments": {
         "path": "/message-attachments",
         "basic": [ "retrieve" ],


### PR DESCRIPTION
Merge tags are internal to Classy and should not be in the public library.