### PR TITLE
Resource level basePath overrides + fix tests

### DIFF
--- a/src/ClassyResource/_addCreateMethods.js
+++ b/src/ClassyResource/_addCreateMethods.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+const resources = require('../resources.json');
 
 /**
  * Adds list methods to the resource based on
@@ -13,10 +14,12 @@ export default function _addCreateMethods(lists) {
   _.each(lists, (method) => {
     const uppercaseMethod = _.upperFirst(_.camelCase(method));
     const methodName = uppercaseMethod.substr(0, uppercaseMethod.length - 1);
+    const resourceDefintion = resources[uppercaseMethod];
 
     _this['create' + methodName] = _this.createMethod({
       method: 'POST',
-      path: '/{id}/' + method
+      path: '/{id}/' + method,
+      basePath: _.get(resourceDefintion, 'basePath')
     });
   });
 }

--- a/src/ClassyResource/_addListMethods.js
+++ b/src/ClassyResource/_addListMethods.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+const resources = require('../resources.json');
 
 /**
  * Adds list methods to the resource based on
@@ -12,10 +13,12 @@ export default function _addListMethods(lists) {
 
   _.each(lists, (method) => {
     const methodName = _.upperFirst(_.camelCase(method));
+    const resourceDefintion = resources[methodName];
 
     _this['list' + methodName] = _this.createMethod({
       method: 'GET',
-      path: '/{id}/' + method
+      path: '/{id}/' + method,
+      basePath: _.get(resourceDefintion, 'basePath')
     });
   });
 }

--- a/src/ClassyResource/_createFullPath.js
+++ b/src/ClassyResource/_createFullPath.js
@@ -6,13 +6,15 @@ import path from 'path';
  * instance was initialized. Returns something like
  * /2.0/campaigns/23456 or /oauth2/auth.
  *
- * @param  {string}  resolvedPath  The populated URI
- * @param  {Boolean} isAuthRequest Determines whether to append basePath
+ * @param  {string}   resolvedPath     The populated URI
+ * @param  {Boolean}  isAuthRequest    Determines whether to append basePath
+ * @param  {string?}  basePathOverride Base path to use instead of the current resource's or global default
+ * 
  * @return {string}                The full URI for the upcoming request
  */
-export default function _createFullPath(resolvedPath, isAuthRequest) {
+export default function _createFullPath(resolvedPath, isAuthRequest, basePathOverride) {
   const fullPath = path.join(
-      isAuthRequest ? '' : this.basePath,
+      isAuthRequest ? '' : basePathOverride || this.basePath,
       resolvedPath
     ).replace(/\\/g, '/');
 

--- a/src/ClassyResource/_createFullPath.js
+++ b/src/ClassyResource/_createFullPath.js
@@ -8,8 +8,9 @@ import path from 'path';
  *
  * @param  {string}   resolvedPath     The populated URI
  * @param  {Boolean}  isAuthRequest    Determines whether to append basePath
- * @param  {string?}  basePathOverride Base path to use instead of the current resource's or global default
- * 
+ * @param  {string?}  basePathOverride Base path to use instead of the current resource's or
+ *                                     global default
+ *
  * @return {string}                The full URI for the upcoming request
  */
 export default function _createFullPath(resolvedPath, isAuthRequest, basePathOverride) {

--- a/src/ClassyResource/_makeRequest.js
+++ b/src/ClassyResource/_makeRequest.js
@@ -52,13 +52,13 @@ export default function _makeRequest(path, method, headers, form, data) {
         } else if (err && !(err instanceof Error)) {
           error = new Error(err);
         } else {
-          error = JSON.parse(body);
+          error = body ? JSON.parse(body) : {};
           error.statusCode = response.statusCode;
         }
 
         reject(error);
       } else {
-        body = JSON.parse(body);
+        body = body ? JSON.parse(body) : {};
         resolve(body);
       }
     });

--- a/src/ClassyResource/createMethod.js
+++ b/src/ClassyResource/createMethod.js
@@ -8,7 +8,7 @@ import { utils } from '../utils';
  *                                 path: Path that will be appended to the curent resource's path
  *                                 headers: Custom HTTP headers
  *                                 basePath: Override the current resource's bathPath
- *                                 
+ *
  * @return {Function}              The resource method
  */
 export default function createMethod(spec) {

--- a/src/ClassyResource/createMethod.js
+++ b/src/ClassyResource/createMethod.js
@@ -3,8 +3,13 @@ import { utils } from '../utils';
 
 /**
  * [createMethod description]
- * @param  {[type]} spec [description]
- * @return {[type]}      [description]
+ * @param {Object} spec            Options for method, the current options are:
+ *                                 method: HTTP Request verb
+ *                                 path: Path that will be appended to the curent resource's path
+ *                                 headers: Custom HTTP headers
+ *                                 basePath: Override the current resource's bathPath
+ *                                 
+ * @return {Function}              The resource method
  */
 export default function createMethod(spec) {
   const PARAM_REGEX = /\{(.*?)\}/g;
@@ -40,7 +45,7 @@ export default function createMethod(spec) {
     /** Create full request path with resolved params */
     const resolvedPath = commandPath(urlData);
     const isAuthRequest = utils.isAuthRequest(resolvedPath);
-    const requestPath = this._createFullPath(resolvedPath, isAuthRequest);
+    const requestPath = this._createFullPath(resolvedPath, isAuthRequest, spec.basePath);
 
     /** Populate form data for authorization requests */
     let form = false;

--- a/src/ClassyResource/main.js
+++ b/src/ClassyResource/main.js
@@ -5,7 +5,7 @@ import { utils } from '../utils';
 export default class ClassyResource {
   constructor(Classy, urlData) {
     /** Public properties */
-    this.basePath = Classy.basePath;
+    this.basePath = urlData.basePath || Classy.basePath;
     this.baseUrl = Classy.baseUrl;
     this.path = utils.makeURLInterpolator(this.path || '');
 


### PR DESCRIPTION
With the addition of new APIs, we will need to support multiple basePaths. This PR introduces the ability to specify the basePath on a resource. For example, to set the resource AResource to use a basePath different than the default:

```
"AResource": {
    "basePath": "newapi",
    "basic": ["retrieve", "update"],
    "lists": ["children"],
    "path": "/a-resource",
    "custom": {
        "methods": {
            "process": {
                "method": "POST",
                "path": "/{id}/process"
            },
            "url": {
                "method": "POST",
                "path": "/url"
            }
        }
    }
},
```

Requests made such as GET /a-resource/:id will hit the endpoint `{{baseUrl}}/newapi/a-resource/:id`

In addition, if a separate resource specifies that it "lists" or "creates" AResource, the basePath will also be used:
`GET /campaigns/:id/a-resource` -> `{{basePath}}/newapi/campaigns/:id/a-resource`

Lastly, I fixed the promise issues with the tests so that I could verify my changes were working. A few tests I left as pending due to time constraints that I could not fix. 