### PR TITLE
[FRS-6257] Add PromoCodes and PromoCodeConfigurations resources

### DIFF
--- a/src/resources.json
+++ b/src/resources.json
@@ -47,6 +47,7 @@
             "messages",
             "message-stats",
             "posts",
+            "promo-codes",
             "updates",
             "stories",
             "questions",
@@ -65,6 +66,7 @@
             "fundraising-pages",
             "messages",
             "posts",
+            "promo-codes",
             "updates",
             "stories",
             "questions",
@@ -405,6 +407,15 @@
         "lists": [ "comments", "likes" ],
         "path": "/posts"
     },
+    "PromoCodes": {
+      "basic": ["retrieve", "update"],
+      "lists": ["ticket-types", "promo-code-configurations"],
+      "path": "/promo-codes"
+    },
+    "PromoCodeConfigurations": {
+      "basic": [ "retrieve", "del", "create" ],
+      "path": "/promo-code-configurations"
+    },
     "Updates": {
         "basic": [ "retrieve", "del", "update" ],
         "creates": [ "comments", "likes" ],
@@ -451,6 +462,7 @@
     },
     "TicketTypes": {
         "basic": [ "retrieve", "update" ],
+        "lists": ["promo-codes", "promo-code-configurations"],
         "path": "/ticket-types"
     },
     "Transactions": {


### PR DESCRIPTION
I've added the PromoCodes and PromoCodeConfigurations endpoints to classy-node. These aren't ready on APIv2 staging yet, but they should be functioning on the api-1576 feature branch.