### PR TITLE
Stringify and create error object for non-200 errors

### DIFF
--- a/src/ClassyResource/_makeRequest.js
+++ b/src/ClassyResource/_makeRequest.js
@@ -54,7 +54,7 @@ export default function _makeRequest(path, method, headers, form, data) {
         } else {
           const errorString = body ? JSON.stringify(body) : 'Non-200 response';
           error = new Error(errorString);
-          error.statusCode = response.statusCode;          
+          error.statusCode = response.statusCode;
         }
 
         reject(error);

--- a/src/ClassyResource/_makeRequest.js
+++ b/src/ClassyResource/_makeRequest.js
@@ -52,14 +52,15 @@ export default function _makeRequest(path, method, headers, form, data) {
         } else if (err && !(err instanceof Error)) {
           error = new Error(err);
         } else {
-          error = body ? JSON.parse(body) : {};
-          error.statusCode = response.statusCode;
+          const errorString = body ? JSON.stringify(body) : 'Non-200 response';
+          error = new Error(errorString);
+          error.statusCode = response.statusCode;          
         }
 
         reject(error);
       } else {
-        body = body ? JSON.stringify(body) : 'Non-200 response';
-        resolve(new Error(body));
+        body = body ? JSON.parse(body) : {};
+        resolve(body);
       }
     });
 

--- a/src/ClassyResource/_makeRequest.js
+++ b/src/ClassyResource/_makeRequest.js
@@ -58,8 +58,8 @@ export default function _makeRequest(path, method, headers, form, data) {
 
         reject(error);
       } else {
-        body = body ? JSON.parse(body) : {};
-        resolve(body);
+        body = body ? JSON.stringify(body) : 'Non-200 response';
+        resolve(new Error(body));
       }
     });
 

--- a/src/ClassyResource/_makeRequest.js
+++ b/src/ClassyResource/_makeRequest.js
@@ -49,11 +49,9 @@ export default function _makeRequest(path, method, headers, form, data) {
         let error;
         if (err && err instanceof Error) {
           error = err;
-          error.statusCode = response.statusCode;
         } else if (err && !(err instanceof Error)) {
           const errorString = JSON.stringify(err);
           error = new Error(errorString);
-          error.statusCode = response.statusCode;
         } else {
           const errorString = body ? JSON.stringify(body) : 'Non-200 response';
           error = new Error(errorString);

--- a/src/ClassyResource/_makeRequest.js
+++ b/src/ClassyResource/_makeRequest.js
@@ -49,8 +49,11 @@ export default function _makeRequest(path, method, headers, form, data) {
         let error;
         if (err && err instanceof Error) {
           error = err;
+          error.statusCode = response.statusCode;
         } else if (err && !(err instanceof Error)) {
-          error = new Error(err);
+          const errorString = JSON.stringify(err);
+          error = new Error(errorString);
+          error.statusCode = response.statusCode;
         } else {
           const errorString = body ? JSON.stringify(body) : 'Non-200 response';
           error = new Error(errorString);


### PR DESCRIPTION
classy-node was previously rejecting with a plain object if there was a non-200 response where the "error" part of request's callback did not exist. Instead, we now stringify the body (or provide a default string) and reject with an Error object.

Now all three paths reject with Error objects, making classy-node's error handling more predictable.