### PR TITLE
Add Members resource

### DIFF
--- a/src/resources.json
+++ b/src/resources.json
@@ -249,6 +249,11 @@
         "lists": [ "organizations", "fundraising-teams", "fundraising-pages" ],
         "path": "/members"
     },
+    "Members": {
+        "basic": [ "retrieve" ],
+        "lists": [ "organizations", "fundraising-teams", "fundraising-pages" ],
+        "path": "/members"
+    },
     "MessageAttachments": {
         "path": "/message-attachments",
         "basic": [ "retrieve" ],


### PR DESCRIPTION
Right now almost every resource uses plural naming. `Member` seems to be an exception. Let's make both available :)