### PR TITLE
Add member token example

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -24,9 +24,13 @@ app.then((response) => {
 
   // member auth request, response stored by app, not classy-node
   classy.oauth.auth({
-    username: process.env.USERNAME,
-    password: process.env.PASSWORD,
+    code: 'VALID_AUTHORIZATION_CODE',
     token: 'app'
-  }).then((response) => {});
+  }).then((response) => {
+    // member token used
+    classy.me.retrieve({
+      token: response
+    });
+  });
 
 });

--- a/example/index.js
+++ b/example/index.js
@@ -19,8 +19,8 @@ const app = classy.app();
 app.then((response) => {
   // app token used
   classy.organizations.retrieve(1, {
-      token: 'app'
-    });
+    token: 'app'
+  });
 
   // member auth request, response stored by app, not classy-node
   classy.oauth.auth({


### PR DESCRIPTION
Right now there isn't any example of how member tokens should be used. Passing `token: memberToken.access_code` to classy-node felt natural, but that wasn't correct.

Updating the example makes the member access token flow more clear (and also removes an invalid flow that was previously removed from the README).

In general I feel that I should be able to pass the full token object or the access code string to classy-node, but that's a problem for another day.