### PR TITLE
Fix unhandled error in promise

### DIFF
--- a/src/ClassyResource/_makeRequest.js
+++ b/src/ClassyResource/_makeRequest.js
@@ -1,5 +1,5 @@
-import _ from "lodash";
-import request from "request";
+import _ from 'lodash';
+import request from 'request';
 
 /**
  * Makes a request to Classy's API.
@@ -15,7 +15,7 @@ export default function _makeRequest(path, method, headers, form, data) {
   let forceQs = null;
 
   if (data.noLog) {
-    headers["x-no-log"] = true;
+    headers['x-no-log'] = true;
     delete data.noLog;
   }
 
@@ -34,7 +34,7 @@ export default function _makeRequest(path, method, headers, form, data) {
       form: form
     };
 
-    if (method === "GET") {
+    if (method === 'GET') {
       requestParams.qs = data;
     } else {
       requestParams.body = JSON.stringify(data);
@@ -45,7 +45,7 @@ export default function _makeRequest(path, method, headers, form, data) {
     }
 
     request(requestParams, (err, response, body) => {
-      if (err || !/^2/.test("" + response.statusCode)) {
+      if (err || !/^2/.test('' + response.statusCode)) {
         let error;
         if (err && err instanceof Error) {
           error = err;
@@ -53,7 +53,7 @@ export default function _makeRequest(path, method, headers, form, data) {
           const errorString = JSON.stringify(err);
           error = new Error(errorString);
         } else {
-          const errorString = body ? JSON.stringify(body) : "Non-200 response";
+          const errorString = body ? JSON.stringify(body) : 'Non-200 response';
           error = new Error(errorString);
           error.statusCode = response.statusCode;
         }

--- a/src/ClassyResource/_makeRequest.js
+++ b/src/ClassyResource/_makeRequest.js
@@ -1,5 +1,5 @@
-import _ from 'lodash';
-import request from 'request';
+import _ from "lodash";
+import request from "request";
 
 /**
  * Makes a request to Classy's API.
@@ -15,7 +15,7 @@ export default function _makeRequest(path, method, headers, form, data) {
   let forceQs = null;
 
   if (data.noLog) {
-    headers['x-no-log'] = true;
+    headers["x-no-log"] = true;
     delete data.noLog;
   }
 
@@ -34,7 +34,7 @@ export default function _makeRequest(path, method, headers, form, data) {
       form: form
     };
 
-    if (method === 'GET') {
+    if (method === "GET") {
       requestParams.qs = data;
     } else {
       requestParams.body = JSON.stringify(data);
@@ -45,7 +45,7 @@ export default function _makeRequest(path, method, headers, form, data) {
     }
 
     request(requestParams, (err, response, body) => {
-      if (err || !/^2/.test('' + response.statusCode)) {
+      if (err || !/^2/.test("" + response.statusCode)) {
         let error;
         if (err && err instanceof Error) {
           error = err;
@@ -53,18 +53,21 @@ export default function _makeRequest(path, method, headers, form, data) {
           const errorString = JSON.stringify(err);
           error = new Error(errorString);
         } else {
-          const errorString = body ? JSON.stringify(body) : 'Non-200 response';
+          const errorString = body ? JSON.stringify(body) : "Non-200 response";
           error = new Error(errorString);
           error.statusCode = response.statusCode;
         }
 
         reject(error);
       } else {
-        body = body ? JSON.parse(body) : {};
-        resolve(body);
+        try {
+          body = body ? JSON.parse(body) : {};
+          resolve(body);
+        } catch (e) {
+          reject(e);
+        }
       }
     });
-
   });
 
   return promise;


### PR DESCRIPTION
If JSON.parse fails within _makeRequest, it can cause applications to crash. To fix this, we catch the error and send it back as a rejected promise.