### PR TITLE
[CL-22] Add handling for PDF file requests

### DIFF
--- a/src/ClassyResource/_makeRequest.js
+++ b/src/ClassyResource/_makeRequest.js
@@ -27,7 +27,7 @@ export default function _makeRequest(path, method, headers, form, data) {
   const promise = new Promise((resolve, reject) => {
     // the encoding param defaults to undefined, which means the response will be stringified
     // we want to preserve the binary encoding for pdfs, so return null in this case
-    const encoding = _.includes(headers['content-type'], 'pdf')
+    const encoding = _.includes(headers['Content-Type'], 'pdf')
       ? null
       : undefined;
 
@@ -68,7 +68,7 @@ export default function _makeRequest(path, method, headers, form, data) {
         reject(error);
       } else {
         // if we're not returning a pdf file, parse body
-        if (!_.includes(response.headers['content-type'], 'pdf')) {
+        if (!_.includes(response.headers['Content-Type'], 'pdf')) {
           body = body ? JSON.parse(body) : {};
         }
         resolve(body);

--- a/src/ClassyResource/_makeRequest.js
+++ b/src/ClassyResource/_makeRequest.js
@@ -27,7 +27,7 @@ export default function _makeRequest(path, method, headers, form, data) {
   const promise = new Promise((resolve, reject) => {
     // the encoding param defaults to undefined, which means the response will be stringified
     // we want to preserve the binary encoding for pdfs, so return null in this case
-    const encoding = _.includes(headers['Accept'], 'pdf')
+    const encoding = _.includes(headers.Accept, 'pdf')
       ? null
       : undefined;
 

--- a/src/ClassyResource/_makeRequest.js
+++ b/src/ClassyResource/_makeRequest.js
@@ -25,14 +25,23 @@ export default function _makeRequest(path, method, headers, form, data) {
   }
 
   const promise = new Promise((resolve, reject) => {
+    // the encoding param defaults to undefined, which means the response will be stringified
+    // we want to preserve the binary encoding for pdfs, so return null in this case
+    const encoding = _.includes(headers['content-type'], 'pdf')
+      ? null
+      : undefined;
+
     const requestParams = {
       baseUrl: this.baseUrl,
       uri: path,
       method: method,
       headers: headers,
       rejectUnauthorized: false,
-      form: form
+      form: form,
+      encoding: encoding
     };
+
+    console.log('requestParams', requestParams); // eslint-disable-line
 
     if (method === 'GET') {
       requestParams.qs = data;
@@ -60,11 +69,13 @@ export default function _makeRequest(path, method, headers, form, data) {
 
         reject(error);
       } else {
-        body = body ? JSON.parse(body) : {};
+        // if we're not returning a pdf file, parse body
+        if (!_.includes(response.headers['content-type'], 'pdf')) {
+          body = body ? JSON.parse(body) : {};
+        }
         resolve(body);
       }
     });
-
   });
 
   return promise;

--- a/src/ClassyResource/_makeRequest.js
+++ b/src/ClassyResource/_makeRequest.js
@@ -71,6 +71,7 @@ export default function _makeRequest(path, method, headers, form, data) {
         if (!_.includes(response.headers['Content-Type'], 'pdf')) {
           body = body ? JSON.parse(body) : {};
         }
+        
         resolve(body);
       }
     });

--- a/src/ClassyResource/_makeRequest.js
+++ b/src/ClassyResource/_makeRequest.js
@@ -27,7 +27,7 @@ export default function _makeRequest(path, method, headers, form, data) {
   const promise = new Promise((resolve, reject) => {
     // the encoding param defaults to undefined, which means the response will be stringified
     // we want to preserve the binary encoding for pdfs, so return null in this case
-    const encoding = _.includes(headers['Content-Type'], 'pdf')
+    const encoding = _.includes(headers['Accept'], 'pdf')
       ? null
       : undefined;
 
@@ -71,7 +71,7 @@ export default function _makeRequest(path, method, headers, form, data) {
         if (!_.includes(response.headers['Content-Type'], 'pdf')) {
           body = body ? JSON.parse(body) : {};
         }
-        
+
         resolve(body);
       }
     });

--- a/src/ClassyResource/_makeRequest.js
+++ b/src/ClassyResource/_makeRequest.js
@@ -41,8 +41,6 @@ export default function _makeRequest(path, method, headers, form, data) {
       encoding: encoding
     };
 
-    console.log('requestParams', requestParams); // eslint-disable-line
-
     if (method === 'GET') {
       requestParams.qs = data;
     } else {

--- a/src/ClassyResource/createMethod.js
+++ b/src/ClassyResource/createMethod.js
@@ -1,5 +1,5 @@
-import _ from 'lodash';
-import { utils } from '../utils';
+import _ from "lodash";
+import { utils } from "../utils";
 
 /**
  * [createMethod description]
@@ -15,15 +15,14 @@ export default function createMethod(spec) {
   const PARAM_REGEX = /\{(.*?)\}/g;
 
   /** Get parameterized request URL and method */
-  const specPath = (!_.isUndefined(spec.path) ? spec.path : '');
+  const specPath = !_.isUndefined(spec.path) ? spec.path : "";
   const fullPath = this._urlData.path + specPath;
   const commandPath = utils.makeURLInterpolator(fullPath);
   const urlParams = utils.getRegexMatches(fullPath, PARAM_REGEX);
-  const requestMethod = _.get(spec, 'method', 'GET').toUpperCase();
+  const requestMethod = _.get(spec, "method", "GET").toUpperCase();
 
   /** Return resource method */
   return (...args) => {
-
     /** Extract data from function arguments */
     const _this = this;
     const urlData = this._populateUrlParams(urlParams, args);
@@ -36,8 +35,15 @@ export default function createMethod(spec) {
 
       if (!arg) {
         throw new Error(
-          'Classy: Argument "' + urlParams[i] + '" required, but got: ' + arg +
-          ' (on API request to ' + requestMethod + ' ' + commandPath(urlData) + ')'
+          'Classy: Argument "' +
+            urlParams[i] +
+            '" required, but got: ' +
+            arg +
+            " (on API request to " +
+            requestMethod +
+            " " +
+            commandPath(urlData) +
+            ")"
         );
       }
     }
@@ -45,7 +51,11 @@ export default function createMethod(spec) {
     /** Create full request path with resolved params */
     const resolvedPath = commandPath(urlData);
     const isAuthRequest = utils.isAuthRequest(resolvedPath);
-    const requestPath = this._createFullPath(resolvedPath, isAuthRequest, spec.basePath);
+    const requestPath = this._createFullPath(
+      resolvedPath,
+      isAuthRequest,
+      spec.basePath
+    );
 
     /** Populate form data for authorization requests */
     let form = false;
@@ -56,49 +66,82 @@ export default function createMethod(spec) {
     /**
      * Token stuff & requests need to be synchronous with refresh
      */
-    return this._chooseToken(form, data).then((response) => {
-      const DEFAULT_REQUEST_HEADERS = {
-        Accept: 'application/json'
-      };
+    return this._chooseToken(form, data).then(
+      response => {
+        const DEFAULT_REQUEST_HEADERS = {
+          Accept: "application/json"
+        };
 
-      let requestHeaders = this._classy.headers || _.merge(DEFAULT_REQUEST_HEADERS, spec.headers);
+        console.log("this is", this); // eslint-disable-line
 
-      if (requestMethod == 'POST'
-        || requestMethod == 'PUT'
-        || requestMethod == 'PATCH'
-        && !isAuthRequest) {
-        requestHeaders['Content-Type'] = 'application/json';
-      }
+        let requestHeaders =
+          this._classy.headers ||
+          _.merge(DEFAULT_REQUEST_HEADERS, spec.headers);
 
-      if (!response) {
-        return this._makeRequest(requestPath, requestMethod, requestHeaders, form, data);
-      }
+        if (
+          requestMethod == "POST" ||
+          requestMethod == "PUT" ||
+          (requestMethod == "PATCH" && !isAuthRequest)
+        ) {
+          requestHeaders["Content-Type"] = "application/json";
+        }
 
-      if (response === 'app') {
-        return this._refreshAppToken().then((response) => {
-          const appToken = _.get(this._classy.appToken, 'access_token', null);
+        if (!response) {
+          return this._makeRequest(
+            requestPath,
+            requestMethod,
+            requestHeaders,
+            form,
+            data
+          );
+        }
+
+        if (response === "app") {
+          return this._refreshAppToken().then(
+            response => {
+              const appToken = _.get(
+                this._classy.appToken,
+                "access_token",
+                null
+              );
+              delete data.token;
+
+              requestHeaders.Authorization = "Bearer " + appToken;
+
+              return this._makeRequest(
+                requestPath,
+                requestMethod,
+                requestHeaders,
+                form,
+                data
+              );
+            },
+            error => {
+              console.error("App token refresh failed: ", error);
+            }
+          );
+        }
+
+        if (response === "member") {
+          const memberToken = _.get(data, "token.access_token", false);
           delete data.token;
 
-          requestHeaders.Authorization = 'Bearer ' + appToken;
+          requestHeaders.Authorization = "Bearer " + memberToken;
 
-          return this._makeRequest(requestPath, requestMethod, requestHeaders, form, data);
-        }, (error) => {
-          console.error('App token refresh failed: ', error);
-        });
+          return this._makeRequest(
+            requestPath,
+            requestMethod,
+            requestHeaders,
+            form,
+            data
+          );
+        }
+      },
+      error => {
+        throw new Error(
+          "No token defined. Expected memberToken object or `token: 'app'`"
+        );
       }
-
-      if (response === 'member') {
-        const memberToken = _.get(data, 'token.access_token', false);
-        delete data.token;
-
-        requestHeaders.Authorization = 'Bearer ' + memberToken;
-
-        return this._makeRequest(requestPath, requestMethod, requestHeaders, form, data);
-      }
-
-    }, (error) => {
-      throw new Error('No token defined. Expected memberToken object or `token: \'app\'`');
-    });
-
+    );
   };
 }


### PR DESCRIPTION
## Changes
- Detect PDF `Accept` header in classy request and use proper encoding parameter (`null`) to preserve PDF binary
- Detect PDF `Content-Type` response header in and do not attempt to parse the data